### PR TITLE
Improve doc on dependencies installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Clone the repository and install all required packages using:
     ```bash
     python3 --version
     ```
-    If Python 3.11 is not installed, run the following script to install it with `pyenv`:
+    If Python 3.11 is not installed, run the following script to install it with `pyenv`. `Git` is required for the script. Make sure `Git` is installed. If needed, you can install it by following the instructions [here](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
     ```bash
     bash install_python.sh
     ```

--- a/README.md
+++ b/README.md
@@ -20,25 +20,85 @@ This repository provides Jupyter notebook examples for accessing and processing 
 ### Install Dependencies
 
 Clone the repository and install all required packages using:
+ 1. **Ensure Python 3.11 is installed**  
+  This project requires **Python 3.11**. You can check your current version with:
+    ```bash
+    python3 --version
+    ```
+    If Python 3.11 is not installed, run the following script to install it with `pyenv`:
+    ```bash
+    bash install_python.sh
+    ```
 
- 1. **Install ecCodes using conda**
+ 2. **Install ecCodes using conda**
+    > ⚠️ **Temporary Setup Notice**  
+    > From **ecCodes 2.37.0** onwards, this step won't be needed as the Python wheel will include the binary automatically. This change is expected to take effect soon.
+
+
     ```bash
     bash install_eccodes.sh
     ```
 
-2. **Install Python dependencies using Poetry**
+ 3. **Install Poetry**  
+  Poetry is used to manage Python dependencies and environments. Install it using the official installer:
+    ```bash
+    curl -sSL https://install.python-poetry.org | python3 -
+    ```
+    Make sure poetry is available in your shell (you may need to restart your terminal or follow the post-install instructions shown after installation).
+
+    Check the version to confirm it's installed:
+    ```bash
+    poetry --version
+    ```
+
+4. **Install Python dependencies using Poetry**
     ```bash
     poetry install
     ```
 
-3. **Install the Jupyter kernel**  
-    Activate the Poetry environment and install the current environment as a Jupyter kernel:
+5. **Install the Jupyter kernel**  
+    Activate the Poetry environment and register it as a Jupyter kernel so it can be used within notebooks:
     ```bash
     poetry shell
     poetry run python -m ipykernel install --user --name=notebooks-nwp-env --display-name "Python (notebooks-nwp-env)"
     ```
-4. **Use the Kernel in Jupyter**   
-    After launching Jupyter, select the custom kernel by navigating to Kernel → Change Kernel → Python (notebooks-nwp-env) in the notebook interface.
+
+6. **Open and run notebooks**  
+    You can run the notebooks using **Visual Studio Code** or **JupyterLab** — whichever you prefer.
+
+    **Option A: Using Visual Studio Code**
+
+    Make sure you have the following VS Code extensions installed:
+
+    - Python
+
+    - Jupyter (by Microsoft)
+
+    Once installed:
+
+    1. Open the project folder in VS Code.
+
+    2. Open the .ipynb notebook file.
+
+    3. When prompted (or from the top-right kernel picker), select the kernel: Python (notebooks-nwp-env)
+    
+    > 💡 If you don't see the environment, restart VS Code after running the kernel installation step.
+    ---
+
+    **Option B: Using JupyterLab**
+
+    If you don't have VS Code or prefer using JupyterLab:
+
+    1. Install JupyterLab inside the Poetry environment (if not already installed):
+        ```bash
+        poetry run pip install jupyterlab
+        ```
+    2. Launch JupyterLab:
+        ```bash
+        poetry run juypter lab
+        ```
+    3. Open your notebook and select the kernel **Python (notebooks-nwp-env)** from the kernel menu.
+
 
 ## 📚 Related Documentation
 

--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ Clone the repository and install all required packages using:
     **Option B: Using JupyterLab**
 
     If you don't have VS Code or prefer using JupyterLab:
-
-    1. Install JupyterLab (if not already installed):
+    1. Install JupyterLab using `pipx`:
         ```bash
-        pip install jupyterlab
+        pipx install jupyterlab
         ```
+        Don’t have `pipx` yet? Get it here: [https://pipx.pypa.io/stable/installation/](https://pipx.pypa.io/stable/installation/)
     2. Launch JupyterLab:
         ```bash
         jupyter lab

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Clone the repository and install all required packages using:
 
  2. **Install ecCodes using conda**
     > ⚠️ **Temporary Setup Notice**  
-    > From **ecCodes 2.37.0** onwards, this step won't be needed as the Python wheel will include the binary automatically. This change is expected to take effect soon.
+    > From **ecCodes 2.37.0** onwards, this step won't be needed as the Python wheel will include the binary for the ecCodes library. This change is expected to take effect soon.
 
 
     ```bash
@@ -52,6 +52,7 @@ Clone the repository and install all required packages using:
     ```
 
 4. **Install Python dependencies using Poetry**
+    Make sure to be at the root of the project's folder.
     ```bash
     poetry install
     ```
@@ -60,7 +61,7 @@ Clone the repository and install all required packages using:
     Activate the Poetry environment and register it as a Jupyter kernel so it can be used within notebooks:
     ```bash
     poetry shell
-    poetry run python -m ipykernel install --user --name=notebooks-nwp-env --display-name "Python (notebooks-nwp-env)"
+    python -m ipykernel install --user --name=notebooks-nwp-env --display-name "Python (notebooks-nwp-env)"
     ```
 
 6. **Open and run notebooks**  
@@ -70,7 +71,7 @@ Clone the repository and install all required packages using:
 
     Make sure you have the following VS Code extensions installed:
 
-    - Python
+    - Python (by Microsoft)
 
     - Jupyter (by Microsoft)
 
@@ -78,7 +79,7 @@ Clone the repository and install all required packages using:
 
     1. Open the project folder in VS Code.
 
-    2. Open the .ipynb notebook file.
+    2. Open a jupyter notebook file, for example 01_retrieve_process_precip.ipynb.
 
     3. When prompted (or from the top-right kernel picker), select the kernel: Python (notebooks-nwp-env)
     
@@ -89,13 +90,13 @@ Clone the repository and install all required packages using:
 
     If you don't have VS Code or prefer using JupyterLab:
 
-    1. Install JupyterLab inside the Poetry environment (if not already installed):
+    1. Install JupyterLab (if not already installed):
         ```bash
-        poetry run pip install jupyterlab
+        pip install jupyterlab
         ```
     2. Launch JupyterLab:
         ```bash
-        poetry run juypter lab
+        jupyter lab
         ```
     3. Open your notebook and select the kernel **Python (notebooks-nwp-env)** from the kernel menu.
 

--- a/install_python.sh
+++ b/install_python.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e  # Stop on error
+
+PYTHON_VERSION="3.11.7"
+
+echo " Installing pyenv..."
+if [ ! -d "$HOME/.pyenv" ]; then
+    curl https://pyenv.run | bash
+else
+    echo "pyenv already installed."
+fi
+
+# Update shell config
+# so that every time you open a new terminal, pyenv is available in your PATH
+if ! grep -q 'pyenv init' ~/.bashrc; then
+    echo " Adding pyenv to ~/.bashrc"
+    cat <<EOF >> ~/.bashrc
+
+# Pyenv setup
+export PATH="\$HOME/.pyenv/bin:\$PATH"
+# Allow python, pip, etc. to point to the correct version of Python managed by pyenv
+eval "\$(pyenv init --path)"
+EOF
+fi
+
+# Apply changes to current session
+export PATH="$HOME/.pyenv/bin:$PATH"
+eval "$(pyenv init --path)"
+
+echo " Installing Python $PYTHON_VERSION with pyenv..."
+if ! pyenv versions --bare | grep -q "^$PYTHON_VERSION\$"; then
+    pyenv install $PYTHON_VERSION
+else
+    echo "Python $PYTHON_VERSION already installed in pyenv."
+fi
+
+echo " Setting Python $PYTHON_VERSION as global version..."
+pyenv global $PYTHON_VERSION
+
+echo "Done! Python version now:"
+python --version

--- a/install_python.sh
+++ b/install_python.sh
@@ -2,7 +2,7 @@
 
 set -e  # Stop on error
 
-PYTHON_VERSION="3.11.7"
+PYTHON_VERSION="3.11"
 
 echo " Installing pyenv..."
 if [ ! -d "$HOME/.pyenv" ]; then

--- a/install_python.sh
+++ b/install_python.sh
@@ -36,7 +36,7 @@ else
 fi
 
 echo " Setting Python $PYTHON_VERSION as global version..."
-pyenv global $PYTHON_VERSION
+pyenv local $PYTHON_VERSION
 
 echo "Done! Python version now:"
 python --version

--- a/install_python.sh
+++ b/install_python.sh
@@ -35,7 +35,7 @@ else
     echo "Python $PYTHON_VERSION already installed in pyenv."
 fi
 
-echo " Setting Python $PYTHON_VERSION as global version..."
+echo " Setting Python $PYTHON_VERSION as local version..."
 pyenv local $PYTHON_VERSION
 
 echo "Done! Python version now:"


### PR DESCRIPTION
After an initial round of feedback on the notebooks, we realized that simply instructing users to run `poetry install` was not sufficient to ensure a smooth setup experience.
This update expands the documentation to more clearly guide users through the full setup process, including:

- Installing Python 3.11 using pyenv

- Installing Poetry

- Setting up the virtual environment

- Installing the Jupyter kernel

- Opening the notebook and selecting the correct kernel (in VS Code or JupyterLab)