### PR TITLE
Support Poetry 2.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository provides Jupyter notebook examples for accessing and processing 
 
 ---
 
-## 📓 Example Notebooks
+## 📓 Notebooks
 
 - [**01_retrieve_process_precip.ipynb**](01_retrieve_process_precip.ipynb) - Retrieve, process, and visualize deterministic precipitation forecasts from the ICON model.
 
@@ -19,38 +19,20 @@ This repository provides Jupyter notebook examples for accessing and processing 
 
 ### Install Dependencies
 
-Clone the repository and install all required packages:
-1. #### Ensure Python 3.11 is installed
-    This project requires **Python 3.11**. You can check your current version with:
-    ```bash
-    python3 --version
-    ```
+Clone the repository and install all required packages. This project requires **Python 3.11** and [Poetry](https://python-poetry.org/docs/) to manage dependencies and environments.
 
-2. #### Install Poetry 1.8.1
-    Poetry is used to manage Python dependencies and environments. Install it using the official installer:
-      ```bash
-      curl -sSL https://install.python-poetry.org | python3 - --version 1.8.1
-      ```
-      Make sure poetry is available in your shell (you may need to restart your terminal or follow the post-install instructions shown after installation).
-
-      Verify that Poetry is installed and check the version:
-      ```bash
-      poetry --version
-      ```
-
-3. #### Install Python dependencies using Poetry
-    Make sure to be at the root of the project's folder.
+1. #### Install Python dependencies using Poetry
     ```bash
     poetry install
     ```
 
-4. #### Install the Jupyter kernel
+2. #### Install the Jupyter kernel
     Activate the Poetry environment and register it as a Jupyter kernel so it can be used within notebooks:
     ```bash
     poetry run python -m ipykernel install --user --name=notebooks-nwp-env --display-name "Python (notebooks-nwp-env)"
     ```
 
-5. #### Open and run notebooks
+3. #### Open and run notebooks
     You can run the notebooks using **Visual Studio Code** or **JupyterLab** — whichever you prefer.
 
     **Option A: Using Visual Studio Code**

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ Clone the repository and install all required packages:
 4. #### Install the Jupyter kernel
     Activate the Poetry environment and register it as a Jupyter kernel so it can be used within notebooks:
     ```bash
-    poetry shell
-    python -m ipykernel install --user --name=notebooks-nwp-env --display-name "Python (notebooks-nwp-env)"
+    poetry run python -m ipykernel install --user --name=notebooks-nwp-env --display-name "Python (notebooks-nwp-env)"
     ```
 
 5. #### Open and run notebooks

--- a/README.md
+++ b/README.md
@@ -32,42 +32,46 @@ Clone the repository and install all required packages. This project requires **
     poetry run python -m ipykernel install --user --name=notebooks-nwp-env --display-name "Python (notebooks-nwp-env)"
     ```
 
-3. #### Open and run notebooks
-    You can run the notebooks using **Visual Studio Code** or **JupyterLab** — whichever you prefer.
+### Open and Run Notebooks
 
-    **Option A: Using Visual Studio Code**
+You can run the notebooks using **Visual Studio Code** or **JupyterLab** — whichever you prefer.
 
-    Make sure you have the following VS Code extensions installed:
+#### Option A: Using Visual Studio Code
 
-    - Python (by Microsoft)
+Make sure you have the following VS Code extensions installed:
 
-    - Jupyter (by Microsoft)
+- Python (by Microsoft)
+- Jupyter (by Microsoft)
 
-    Once installed:
+Once installed:
 
-    1. Open the project folder in VS Code.
+1. Open the project folder in VS Code.
+2. Open a Jupyter notebook file, for example `01_retrieve_process_precip.ipynb`.
+3. When prompted (or from the top-right kernel picker), select the kernel: **Python (notebooks-nwp-env)**.
 
-    2. Open a jupyter notebook file, for example 01_retrieve_process_precip.ipynb.
+> 💡 If you don't see the environment, restart VS Code after running the kernel installation step.
 
-    3. When prompted (or from the top-right kernel picker), select the kernel: Python (notebooks-nwp-env)
+---
 
-    > 💡 If you don't see the environment, restart VS Code after running the kernel installation step.
-    ---
+#### Option B: Using JupyterLab
 
-    **Option B: Using JupyterLab**
+If you don't have VS Code or prefer using JupyterLab:
 
-    If you don't have VS Code or prefer using JupyterLab:
-    1. Install JupyterLab using `pipx`:
-        ```bash
-        pipx install jupyterlab
-        ```
-        Don’t have `pipx` yet? Get it here: [https://pipx.pypa.io/stable/installation/](https://pipx.pypa.io/stable/installation/)
-    2. Launch JupyterLab:
-        ```bash
-        jupyter lab
-        ```
-    3. Open your notebook and select the kernel **Python (notebooks-nwp-env)** from the kernel menu.
+1. Install JupyterLab using `pipx`:
 
+    ```bash
+    pipx install jupyterlab
+    ```
+
+    Don’t have `pipx` yet? Get it here: [https://pipx.pypa.io/stable/installation/](https://pipx.pypa.io/stable/installation/)
+
+2. Launch JupyterLab:
+
+    ```bash
+    jupyter lab
+    ```
+
+3. Open your notebook and select the kernel **Python (notebooks-nwp-env)** from the kernel menu.
 
 ## 📚 Related Documentation
 


### PR DESCRIPTION
https://python-poetry.org/blog/announcing-poetry-2.0.0/#poetry-export-and-poetry-shell-only-available-via-plugins

`poetry shell` is no longer part of poetry 2.0. It seems much easier to just create the kernel with `poetry run`. Then it is a single command, and also works easily if you are using a combination of conda and poetry. (I struggled with `poetry env activate` with my setup so I dont recommend that)