### PR TITLE
run the jenkins job daily at 1:30 AM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,10 @@ pipeline {
     agent {
         label 'redhat'
     }
+    triggers {
+        // Run the job daily at 1:30 AM
+        cron('30 1 * * *')
+    }
     environment {
         PATH = "$workspace/.venv-mchbuild/bin:$PATH"
         HTTP_PROXY = 'http://proxy.meteoswiss.ch:8080'


### PR DESCRIPTION
This PR enables the Jenkins plan introduced in [#16](https://github.com/MeteoSwiss/opendata-nwp-demos/pull/16) to run on a daily schedule.

Although we don't push changes every day, we want to be notified promptly if something breaks — for example, if data retrieval fails due to missing or delayed new data.

Jira task: https://meteoswiss.atlassian.net/browse/OG-22