### PR TITLE
Upgrade to mchbuild 1.0

### DIFF
--- a/.mch-ci.yml
+++ b/.mch-ci.yml
@@ -7,5 +7,5 @@ default:
           packageManager: ''         # disable automatically adding the 'poetry run' prefix to each command
           commands: |-
             poetry install --with test
-            poetry run python -m ipykernel install --user --name=notebooks-nwp-env --display-name "Python (notebooks-nwp-env)" &&
+            poetry run python -m ipykernel install --user --name=notebooks-nwp-env --display-name "Python (notebooks-nwp-env)"
             poetry run python check_notebooks.py

--- a/.mch-ci.yml
+++ b/.mch-ci.yml
@@ -3,8 +3,9 @@ default:
     - notebooks_execution:
         pythonContainerRun:
           pythonVersion: '3.11'
-          installDependencies: true
-          # Note: the 'poetry run' prefix is automatically added to each command
+          installDependencies: false # would execute "poetry install --with-extras", without optional 'test' dependency
+          packageManager: ''         # disable automatically adding the 'poetry run' prefix to each command
           commands: |-
-            python -m ipykernel install --user --name=notebooks-nwp-env --display-name "Python (notebooks-nwp-env)" &&
-            python check_notebooks.py
+            poetry install --with test
+            poetry run python -m ipykernel install --user --name=notebooks-nwp-env --display-name "Python (notebooks-nwp-env)" &&
+            poetry run python check_notebooks.py

--- a/.mch-ci.yml
+++ b/.mch-ci.yml
@@ -1,9 +1,10 @@
 default:
   - test:
     - notebooks_execution:
-        pythonRun:
-          pythonImageName: 3.11
-          commands: >
-            poetry install --with test &&
-            poetry run python -m ipykernel install --user --name=notebooks-nwp-env --display-name "Python (notebooks-nwp-env)" &&
-            poetry run python check_notebooks.py
+        pythonContainerRun:
+          pythonVersion: '3.11'
+          installDependencies: true
+          # Note: the 'poetry run' prefix is automatically added to each command
+          commands: |-
+            python -m ipykernel install --user --name=notebooks-nwp-env --display-name "Python (notebooks-nwp-env)" &&
+            python check_notebooks.py

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
 The pipeline which checks the execution of the notebooks failed:
 ${env.BUILD_URL}
                 """,
-                to: env.BRANCH_NAME == 'main' ? "nina.burgdorfer@meteoswiss.ch" : "",
+                to: env.BRANCH_NAME == 'main' ? "p_polytope@meteoswiss.ch" : "",
                 recipientProviders: [requestor(), developers()]
             )
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,11 @@
 class Globals {
 
     // Pin mchbuild to stable version to avoid breaking changes
-    static String mchbuildVersion = '0.8.0'
+    static String mchbuildPipPackage = 'mchbuild>=1.0.0,<2.0.0'
 }
 pipeline {
     agent {
-        label 'redhat'
+        label 'podman'
     }
     triggers {
         // Run the job daily at 3:30 UTC
@@ -29,11 +29,11 @@ pipeline {
         stage('Setup') {
             steps {
                 script {
-                    echo "---- INSTALL MCHBUILD ----"
+                    echo '---- INSTALLING MCHBUILD ----'
                     sh """
-                    python -m venv .venv-mchbuild
-                    PIP_INDEX_URL=https://hub.meteoswiss.ch/nexus/repository/python-all/simple \
-                    .venv-mchbuild/bin/pip install mchbuild==${Globals.mchbuildVersion}
+                        python -m venv .venv-mchbuild
+                        PIP_INDEX_URL=https://hub.meteoswiss.ch/nexus/repository/python-all/simple \
+                            .venv-mchbuild/bin/pip install --upgrade "${Globals.mchbuildPipPackage}"
                     """
                 }
             }
@@ -61,7 +61,7 @@ pipeline {
 The pipeline which checks the execution of the notebooks failed:
 ${env.BUILD_URL}
                 """,
-                to: "nina.burgdorfer@meteoswiss.ch",
+                to: env.BRANCH_NAME == 'main' ? "nina.burgdorfer@meteoswiss.ch" : "",
                 recipientProviders: [requestor(), developers()]
             )
         }
@@ -73,5 +73,3 @@ ${env.BUILD_URL}
         }
     }
 }
-
-


### PR DESCRIPTION
- Upgrade to mchbuild 1.0
- Replace the `pythonRun` task with `pythonContainerRun`, since `pythonRun` is no longer available. Unfortunately, there does not appear to be a way to modify the automatic dependency installation to include the optional 'test' dependencies (`installDependencies: true` results in `poetry install --all-extras`). The installation is thus kept as a manual command, and the automatic `poetry run` prefix disabled.
- Use podman instead of redhat Jenkins agent
- Only send a mail to p_polytope if tests on the main branch fail